### PR TITLE
Added error handling for chardet returning non-supported “EUC-TW” or …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .idea/
+venv/

--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
 # ID3 Encoding Fixer
 ID3 Encoding Fixer converts encoding of ID3 tags in MP3 files to the right one.
 
-## Dependencies
-* chardet
-* mutagen
-
 
 ## Usage
 ### Install dependencies
 ```
-$ pip install chardet mutagen
+$ pip install -r requirements.txt
 ```
 ### Run if encoding is unknown.
 ```

--- a/fixer/convert.py
+++ b/fixer/convert.py
@@ -57,6 +57,10 @@ def fix_save(path, encoding):
                     continue
                 except UnicodeDecodeError:
                     continue
+                except LookupError:
+                    continue
+                except AssertionError:
+                    continue
                 fixed_values.append(decoded_text)
 
             if len(fixed_values) > 0:
@@ -84,10 +88,13 @@ def convert_encoding(text, encoding=None):
             exaggerated_raw += raw
         detected = chardet.detect(exaggerated_raw)
         encoding = detected['encoding']
+        assert isinstance(encoding, str)
 
         try:
             decoded_text = raw.decode(encoding=encoding)
         except UnicodeDecodeError as e:
+            raise e
+        except LookupError as e:
             raise e
 
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+chardet
+mutagen


### PR DESCRIPTION
- moved dependencies to requirements.txt
- added error handling for None or non-supported encoding